### PR TITLE
Patch 1

### DIFF
--- a/oric/src/index.md
+++ b/oric/src/index.md
@@ -1,54 +1,23 @@
-# A guide for Aboriginal and Torres Strait Islander corporations using Loomio for good decision-making
+# A guide for Aboriginal and Torres Strait Islander corporations using Loomio for good decision-making and accountable governance
 
-*This guide is intended for participants of the ORIC–Loomio pilot program, but it may be of interest to anyone seeking help to use Loomio for good governance.*
+*This guide is intended for corporations in the ORIC–Loomio pilot program, but it may be of interest to anyone seeking help to use Loomio for good governance.*
 
-Loomio offers an opportunity to strengthen governance, to extend collaboration beyond board meetings, and to include everyone in open, honest and respectful discussion—while documenting everything.
-
-This guide—and the templates it contains—is designed to help directors use digital tools effectively to improve communication and governance.
-
-## Letter of invitation to Pilot
-An invitation to the ORIC Loomio Pilot programme and to join a first call via Zoom.
-- [Letter of invitation](letter.md)
-
-## Technology for Governance and Loomio introduction video
-
-Video introduction by Rahul Watson Govindan, CEO Loomio, presenting at the ORIC Governance online forum on 30 November 2021.
-
-Rahul outlines the need and value of technology for good governance and introduces Loomio with a short demonstration.
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/8SX17Ici-y4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-## Guides
-Click on the links below to go to the guide you are interested in.
-- [Loomio key concepts](key-concepts.md)
-- [Onboarding to Loomio](onboarding.md)
-- [Guide for Director users](guide-directors.md)
-- [Guide for Connectors](guide-connectors.md)
-
-## Good governance guides
-Good governance exists where an organisation has systems and processes in place that are appropriate to its circumstances, and which enable the organisation to pursue its purpose effectively and meet its obligations under the law.
+Good governance happens when directors understand their corporation's **context** and set up a system and processes to serve its **purpose** and meet their **obligations** under the law.
 
 *“It is participatory, consensus-oriented, accountable, transparent, responsive, effective and efficient, equitable and inclusive and follows the rule of law.”*
 
-Underpinning all of these principles is good communication.
+At its heart is open communication.
 
-Use these guides to help improve governance in your organisation:
-- [Introducing a new online tool to your organisation](intro-online.md)
-- [Approving financial reports](approving-financials.md)
-- [Questioning Financial statements](questioning-financials.md)
+Use Loomio to strengthen governance: **collaborate** beyond board meetings, **include everyone** in open, honest and respectful discussion, and **document everything** as you go.
 
-## Templates
-See your Loomio Demo Group for templates and examples for preparing board meetings, follow up minutes and actions, voting on resolutions, and enabling subcommittees to make recommendations or decisions.
+This guide—and the templates it contains—will help your board to **communicate well**, **make good decisions** and **be accountable**.
 
-Click on these links for template examples in the Demo group:
+## Contents
+- [Loomio key concepts](key-concepts.md)
+- [Guide for directors using Loomio](guide-directors.md)
+- [Guide for connectors managing Loomio for their corporation](guide-connectors.md)
 
-- [Loomio board meeting template](https://decisions.oric.gov.au/d/FJHrQD2b/loomio-board-meeting-template)
-- [Notice of Directors' meeting - Word Template](https://decisions.oric.gov.au/d/9SDCRbrx/notice-of-directors-meeting-word-template)
-- [Processing Applications for Membership - Template](https://decisions.oric.gov.au/d/lTZv4K2f/processing-applications-for-membership-template)
-- [Thread for an out-of-session decision - Template](https://decisions.oric.gov.au/d/3wRYMFUg/thread-for-an-out-of-session-decision)
+## Templates and Loomio sandpit
+See the [Board Demo Group](https://decisions.oric.gov.au/loomio-demo-group/) for templates and examples for planning board meetings, drafting minutes, assigning actions, voting on resolutions, and enabling subcommittees to make recommendations or decisions. Think of it as a sandpit. Feel free to play around, respond to a thread or a poll, or create your own. 
 
----
-*We acknowledge the traditional custodians throughout Australia; recognise their continuing connection to land, waters and culture; and pay our respects to elders past, present and emerging.*
-
-
-Unless specified otherwise, content on this site is licensed under a [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/) (CC BY-SA 4.0) 
+Content on this site is licensed under a [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/) (CC BY-SA 4.0) 

--- a/oric/src/index.md
+++ b/oric/src/index.md
@@ -20,4 +20,5 @@ This guide—and the templates it contains—will help your board to **communica
 ## Templates and Loomio sandpit
 See the [Board Demo Group](https://decisions.oric.gov.au/loomio-demo-group/) for templates and examples for planning board meetings, drafting minutes, assigning actions, voting on resolutions, and enabling subcommittees to make recommendations or decisions. Think of it as a sandpit. Feel free to play around, respond to a thread or a poll, or create your own. 
 
+---
 Content on this site is licensed under a [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/) (CC BY-SA 4.0) 

--- a/oric/src/index.md
+++ b/oric/src/index.md
@@ -21,4 +21,4 @@ This guide—and the templates it contains—will help your board to **communica
 See the [Board Demo Group](https://decisions.oric.gov.au/loomio-demo-group/) for templates and examples for planning board meetings, drafting minutes, assigning actions, voting on resolutions, and enabling subcommittees to make recommendations or decisions. Think of it as a sandpit. Feel free to play around, respond to a thread or a poll, or create your own. 
 
 ---
-Content on this site is licensed under a [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/) (CC BY-SA 4.0) 
+You are free to use the content of this guide under the [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/) (CC BY-SA 4.0) 

--- a/oric/src/index.md
+++ b/oric/src/index.md
@@ -1,10 +1,10 @@
-# Introduction to guides and templates for the ORIC Loomio pilot programme
+# A guide for Aboriginal and Torres Strait Islander corporations using Loomio for good decision-making
 
-*This is an introduction to the ORIC Loomio Governance guides.  It is intended for participants of the ORIC Loomio Pilot programme, however may be of interest to anyone seeking help to use Loomio for good governance.*
+*This guide is intended for participants of the ORIC–Loomio pilot program, but it may be of interest to anyone seeking help to use Loomio for good governance.*
 
-Loomio offers an opportunity to strengthen governance, to extend collaboration beyond board meetings, to include everyone in open, honest and respectful discussion while documenting everything.
+Loomio offers an opportunity to strengthen governance, to extend collaboration beyond board meetings, and to include everyone in open, honest and respectful discussion—while documenting everything.
 
-This series of guides and templates is designed to help directors use digital communication tools effectively to improve communication and governance.
+This guide—and the templates it contains—is designed to help directors use digital tools effectively to improve communication and governance.
 
 ## Letter of invitation to Pilot
 An invitation to the ORIC Loomio Pilot programme and to join a first call via Zoom.

--- a/oric/src/index.md
+++ b/oric/src/index.md
@@ -12,7 +12,7 @@ Use Loomio to strengthen governance: **collaborate** beyond board meetings, **in
 
 This guide—and the templates it contains—will help your board to **communicate well**, **make good decisions** and **be accountable**.
 
-## Contents
+## Within this guide
 - [Loomio key concepts](key-concepts.md)
 - [Guide for directors using Loomio](guide-directors.md)
 - [Guide for connectors managing Loomio for their corporation](guide-connectors.md)


### PR DESCRIPTION
Hi Michael,
I've pared down the guide intro by taking out:
- parts for ORIC (inviting corps to join the pilot, onboarding corps) 
- parts for corporations before they get into Loomio (the video of Rahul,  advice on introducing the corporation to a new tool) and 
- adjunct materials that could be in an appendix (approving and questioning financial reports). 

I also made it shorter, more active voice, more lower-case etc.

I would now carry on to edit the 
- key concepts
- guide for directors and 
- guide for connectors 
but I'm not sure whether that requires a new fork or what, because I couldn't get to those .md pages via the links in my revised intro. (They just sent me to a long list of materials that are bigger than the ORIC project.)