### PR TITLE
Add camplight guide to "making decisions" examples

### DIFF
--- a/en/src/user_manual/making_decisions/index.md
+++ b/en/src/user_manual/making_decisions/index.md
@@ -27,6 +27,8 @@ Check out these common decision making processes and how to apply these within L
 
 ## Examples of organizations practicing inclusive decision making
 
+- [Camplight Guidebook](https://camplight.net/wp-content/uploads/2023/05/Copy-of-Camplight-Illustrated-Guidebook-6.0-EN.pdf)
+
 - [Raise Teal Operating System](https://teal.raiserecruiting.com/)
 
 - [Greaterthan Handbook](https://handbook.greaterthan.works/)


### PR DESCRIPTION
Adds the camplight guidebook to our making decisions page, where there is an existing list of organizational handbooks and guides.