### PR TITLE
simplify margin definition

### DIFF
--- a/en/theme/css/custom.css
+++ b/en/theme/css/custom.css
@@ -29,8 +29,6 @@
         grid-column: 1;
         grid-row: 1;
         max-width: var(--content-max-width);
-        margin-inline-start: auto;
-        margin-inline-end: 0;
         margin: auto;
     }
     .content .nav-wrapper {


### PR DESCRIPTION
I am not sure what is being added using margin-inline-start/end.

These are used when you need to keep the writing orientation in mind, but it will always be left to right in these docs.  I think it is better to keep it simple, unless I am missing an additional feature.